### PR TITLE
Set cron to be an accessible attribute

### DIFF
--- a/lib/delayed_cron_job.rb
+++ b/lib/delayed_cron_job.rb
@@ -10,10 +10,10 @@ end
 
 if defined?(Delayed::Backend::Mongoid)
   Delayed::Backend::Mongoid::Job.field :cron, :type => String
-  Delayed::Backend::Mongoid::Job.attr_accessible(:cron)
+  Delayed::Backend::Mongoid::Job.attr_accessible(:cron) if Delayed::Backend::Mongoid::Job.respond_to?(:attr_accessible)
 end
 
-if defined?(Delayed::Backend::ActiveRecord)
+if defined?(Delayed::Backend::ActiveRecord) && Delayed::Backend::ActiveRecord::Job.respond_to?(:attr_accessible)
   Delayed::Backend::ActiveRecord::Job.attr_accessible(:cron)
 end
 

--- a/lib/delayed_cron_job.rb
+++ b/lib/delayed_cron_job.rb
@@ -10,6 +10,11 @@ end
 
 if defined?(Delayed::Backend::Mongoid)
   Delayed::Backend::Mongoid::Job.field :cron, :type => String
+  Delayed::Backend::Mongoid::Job.attr_accessible(:cron)
+end
+
+if defined?(Delayed::Backend::ActiveRecord)
+  Delayed::Backend::ActiveRecord::Job.attr_accessible(:cron)
 end
 
 DelayedCronJob::Plugin.callback_block.call(Delayed::Worker.lifecycle)


### PR DESCRIPTION
On Rails 4, the "cron" attribute of the Delayed::Job record was not being set, and always saved as nil. It was necessary to set it as an accessible attribute explicitly. That's what this pul request implements.