### PR TITLE
Implementing the possibility to use a dynamic cron interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ Any crontab compatible cron expressions are supported (see `man 5 crontab`).
 The credits for the `Cronline` class used go to
 [rufus-scheduler](https://github.com/jmettraux/rufus-scheduler).
 
+You can also pass a method name to the `cron` option, but your payload object
+must respond to this method (which receives the job as a parameter) and this 
+method must return a valid cron expression. This way, the interval doesn't 
+need to be fixed. You can, for example, run the job everyday on the first 
+10 days and then just run it once a week. For example:
+    
+    Delayed::Job.enqueue(MyRepeatedJob.new, cron: :cron_calculator)
+
+```ruby
+class MyRepeatedJob < Struct.new
+  def perform
+  end
+
+  def cron_calculator(job)
+    if job.attempts > 10
+      '0 0 * * 0'
+    else
+      '0 0 * * *'
+    end
+  end
+end
+```
+
 ## Details
 
 The initial `run_at` value is computed during the `#enqueue` method call.

--- a/lib/delayed_cron_job/plugin.rb
+++ b/lib/delayed_cron_job/plugin.rb
@@ -4,7 +4,11 @@ module DelayedCronJob
     class << self
       def next_run_at(job)
         cron = job.payload_object.respond_to?(job.cron) ? job.payload_object.send(job.cron, job) : job.cron
-        job.run_at = Cronline.new(cron).next_time(Delayed::Job.db_time_now)
+        if cron.nil?
+          job.cron = nil
+        else
+          job.run_at = Cronline.new(cron).next_time(Delayed::Job.db_time_now)
+        end
       end
 
       def cron?(job)

--- a/lib/delayed_cron_job/plugin.rb
+++ b/lib/delayed_cron_job/plugin.rb
@@ -3,7 +3,8 @@ module DelayedCronJob
 
     class << self
       def next_run_at(job)
-        job.run_at = Cronline.new(job.cron).next_time(Delayed::Job.db_time_now)
+        cron = job.payload_object.respond_to?(job.cron) ? job.payload_object.send(job.cron, job) : job.cron
+        job.run_at = Cronline.new(cron).next_time(Delayed::Job.db_time_now)
       end
 
       def cron?(job)

--- a/lib/delayed_cron_job/plugin.rb
+++ b/lib/delayed_cron_job/plugin.rb
@@ -3,7 +3,7 @@ module DelayedCronJob
 
     class << self
       def next_run_at(job)
-        cron = job.payload_object.respond_to?(job.cron) ? job.payload_object.send(job.cron, job) : job.cron
+        cron = job.payload_object.respond_to?(:run_next_at) ? job.payload_object.send(:run_next_at, job) : job.cron
         if cron.nil?
           job.cron = nil
         else

--- a/spec/delayed_cron_job_spec.rb
+++ b/spec/delayed_cron_job_spec.rb
@@ -4,11 +4,6 @@ describe DelayedCronJob do
 
   class TestJob
     def perform; end
-
-    def cron_method(job)
-      return nil if job.attempts > 10
-      job.attempts % 2 === 0 ? '0 0 1 2 *' : '0 0 1 1 *'
-    end
   end
 
   before { Delayed::Job.delete_all }
@@ -145,7 +140,14 @@ describe DelayedCronJob do
     end
 
     it 'can use dynamic cron' do
-      Delayed::Job.enqueue(handler, cron: :cron_method)
+      class TestJob
+        define_method(:run_next_at) do |job|
+          return nil if job.attempts > 10
+          job.attempts % 2 === 0 ? '0 0 1 2 *' : '0 0 1 1 *'
+        end
+      end
+
+      Delayed::Job.enqueue(handler, cron: '* * * * *')
       j = Delayed::Job.first
       j.update(run_at: j.run_at.last_year, attempts: 11)
 
@@ -153,7 +155,14 @@ describe DelayedCronJob do
     end
 
     it 'ignores if cron is nil' do
-      Delayed::Job.enqueue(handler, cron: :cron_method)
+      class TestJob
+        define_method(:run_next_at) do |job|
+          return nil if job.attempts > 10
+          job.attempts % 2 === 0 ? '0 0 1 2 *' : '0 0 1 1 *'
+        end
+      end
+
+      Delayed::Job.enqueue(handler, cron: '* * * * *')
 
       j = Delayed::Job.first
       expect(j.run_at.month).to eq(2)


### PR DESCRIPTION
Sometimes we don't want the cron interval to be fixed. It can be adjusted based on certain conditions.

This commit makes it possible. You can pass a method name to the `cron` option, but your payload object must respond to this method (which receives the job as a parameter) and this method must return a valid cron expression. This way, the interval doesn't need to be fixed. You can, for example, run the job everyday on the first 10 days and then just run it once a week. For example:

```
Delayed::Job.enqueue(MyRepeatedJob.new, cron: :cron_calculator)
```

``` ruby
class MyRepeatedJob < Struct.new
  def perform
  end

  def cron_calculator(job)
    if job.attempts > 10
      '0 0 * * 0'
    else
      '0 0 * * *'
    end
  end
end
```

Includes an automated test for this feature and updated documentation with example.
