### PR TITLE
Added require statement for delayed_job_active_record and delayed_job_mongoid

### DIFF
--- a/lib/delayed_cron_job.rb
+++ b/lib/delayed_cron_job.rb
@@ -5,6 +5,14 @@ require 'delayed_cron_job/plugin'
 require 'delayed_cron_job/version'
 require 'delayed_cron_job/backend/updatable_cron'
 
+begin
+  require 'delayed_job_active_record'
+rescue LoadError; end
+
+begin
+  require 'delayed_job_mongoid'
+rescue LoadError; end
+
 module DelayedCronJob
 
 end


### PR DESCRIPTION
This just requires the optional gems `delayed_job_active_record` and `delayed_job_mongoid`. Without this, the order of the gems in the Gemfile affects whether `Delayed::Backend::ActiveRecord` and `Delayed::Backend::Mongoid` are defined or not.