### PR TITLE
Add migration version number for rails 5.1

### DIFF
--- a/lib/generators/delayed_job/templates/cron_migration.rb
+++ b/lib/generators/delayed_job/templates/cron_migration.rb
@@ -1,4 +1,4 @@
-class AddCronToDelayedJobs < ActiveRecord::Migration
+class AddCronToDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     add_column :delayed_jobs, :cron, :string
   end


### PR DESCRIPTION
Since rails 5, migrations are versioned. For rails 5.1, the rails version of this migration has to be explicitly included. Otherwise, the following error will occur:

StandardError: Directly inheriting from ActiveRecord::Migration is not supported.

See http://blog.bigbinary.com/2016/03/01/migrations-are-versioned-in-rails-5.html for more details.