### PR TITLE
Add hint about gem order to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ cron expressions for your jobs to run repeatedly.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add the following line to your application's Gemfile. Add it after the lines for all other `delayed_job*` gems so the gem can properly integrate with the Delayed::Job code.
 
     gem 'delayed_cron_job'
 


### PR DESCRIPTION
Lesson learned when using ActiveRecord: If you list the gems in the wrong order your workers won't `set_next_run_at` and get stuck in an endless loop.

Root cause of this is `Delayed::Backend::ActiveRecord` not being defined when delayed_cron_job.rb is executed.
Not quite sure if either `defined?(Delayed::Backend::ActiveRecord)` or `defined?(Delayed::Backend::Mongoid)` must evaluate to true - if yes, we could warn the user if neither does.