### PR TITLE
Remove Fixnum deprecation warnings on ruby 2.4.0

### DIFF
--- a/lib/delayed_cron_job/cronline.rb
+++ b/lib/delayed_cron_job/cronline.rb
@@ -74,7 +74,7 @@ module DelayedCronJob
 
         raise ArgumentError.new(
           "invalid cronline: '#{line}'"
-        ) if es && es.find { |e| ! e.is_a?(Fixnum) }
+        ) if es && es.find { |e| ! e.is_a?(Integer) }
       end
     end
 


### PR DESCRIPTION
Fixnum and Bignum were unified into the Integer class in 2.4.0, this fixes the issue.

Integer was still the superclass for Fixnum, so this should also work on versions prior to 2.4.0.