### PR TITLE
Intercepts destroy and reschedules the existing job record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
- - "2.3.0"
+ - "2.5.8"
 
 sudo: false
 

--- a/lib/delayed_cron_job.rb
+++ b/lib/delayed_cron_job.rb
@@ -4,6 +4,7 @@ require 'delayed_cron_job/cronline'
 require 'delayed_cron_job/plugin'
 require 'delayed_cron_job/version'
 require 'delayed_cron_job/backend/updatable_cron'
+require 'delayed_cron_job/backend/cron_job_proxy'
 
 begin
   require 'delayed_job_active_record'

--- a/lib/delayed_cron_job/backend/cron_job_proxy.rb
+++ b/lib/delayed_cron_job/backend/cron_job_proxy.rb
@@ -1,0 +1,45 @@
+module DelayedCronJob
+  module Backend
+    class CronJobProxy
+      instance_methods.each do |m|
+        undef_method(m) unless m =~ /(^__|^nil\?$|^send$|^object_id$)/
+      end
+
+      def initialize(target)
+        @target = target
+      end
+
+      def destroy
+        if cron.present?
+          # intercept and reschedule the existing record, instead
+          reschedule
+        else
+          super
+        end
+      end
+
+      def respond_to?(symbol, include_priv=false)
+        @target.respond_to?(symbol, include_priv)
+      end
+
+      def ==(other) #:nodoc:
+        self.object_id == other.object_id
+      end
+
+      private
+
+      def method_missing(method, *args, &block)
+        @target.send(method, *args, &block)
+      end
+
+      def reschedule
+        @target.locked_at = nil
+        @target.locked_by = nil
+        @target.attempts += 1
+        @target.set_next_run_at
+        @target.unlock
+        @target.save!
+      end
+    end
+  end
+end

--- a/lib/delayed_cron_job/plugin.rb
+++ b/lib/delayed_cron_job/plugin.rb
@@ -10,7 +10,7 @@ module DelayedCronJob
     callbacks do |lifecycle|
 
       # Prevent rescheduling of failed jobs as this is already done
-      # after perform.
+      # when attempted to be destroyed.
       lifecycle.around(:error) do |worker, job, &block|
         if cron?(job)
           job.error = $ERROR_INFO

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ ENV['RAILS_ENV'] = 'test'
 
 ActiveJob::Base.queue_adapter = :delayed_job
 
-ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => ':memory:'
+ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => 'file::memory:?cache=shared'
 ActiveRecord::Base.logger = Delayed::Worker.logger
 ActiveRecord::Migration.verbose = false
 


### PR DESCRIPTION
We use delayed_cron_job pretty heavily and have run into situations where cron delayed_jobs get destroyed because the destroy and create don't happen inside a transaction. Quite often, we have seen the job complete, be destroyed, then fail to be recreated due to a timeout in getting a database connection. When this happens, the cron job is completely lost.

I'm not sure if using a proxy is the best approach to fixing the problem, but didn't want to copy more of the delayed_job code just to intercept the destroy. This will create a proxy on the delayed job and intercept an attempt to destroy a cron job and instead reschedule the job. This prevents the destroy and recreation from happening in separate transactions, and worst case scenario, will run the job again, instead of losing the cron job all together.