### PR TITLE
make rubocop happy with the example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ namespace :db do
     # Need to load all jobs definitions in order to find subclasses
     glob = Rails.root.join('app', 'jobs', '**', '*_job.rb')
     Dir.glob(glob).each { |file| require file }
-    CronJob.subclasses.each { |job| job.schedule }
+    CronJob.subclasses.each(&:schedule)
   end
 end
 


### PR DESCRIPTION
```
lib/tasks/jobs.rake:5:29: C: [Correctable] Style/SymbolProc: Pass &:schedule as an argument to each instead of a block.
    CronJob.subclasses.each { |job| job.schedule }
                            ^^^^^^^^^^^^^^^^^^^^^^
```