### PR TITLE
Remove hard dependency on delayed_job (#32)

### DIFF
--- a/delayed_cron_job.gemspec
+++ b/delayed_cron_job.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "delayed_job", ">= 4.1"
   spec.add_dependency "fugit", ">= 1.5"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
This allows to use alternative implementations of delayed job.