### PR TITLE
Correct Custom CronJob superclass example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class CronJob < ApplicationJob
     def delayed_job
       Delayed::Job
         .where('handler LIKE ?', "%job_class: #{name}%")
-        .where(last_error: nil)
+        .where(failed_at: nil) # ignore failed jobs if destroy_failed_jobs == false
         .first
     end
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ class CronJob < ApplicationJob
     def delayed_job
       Delayed::Job
         .where('handler LIKE ?', "%job_class: #{name}%")
+        .where(last_error: nil)
         .first
     end
 


### PR DESCRIPTION
This PR helps avoid a lot of problems in a very specific scenario. 
In case that your delayed job setting persist failed jobs in DB we need to add that line into example `Custom CronJob superclass` to not consider it as an already scheduled job of given type. That way, in `delayed_job` we only take active jobs under consideration. 